### PR TITLE
Support for running in a highly locked-down environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   -A, --all-versions-recursive  download all versions of specified packages and dependencies
   -c, --concurrency <n>         number of requests to make at the same time - default=50
   -r, --registry <registry>     specify a registry
+  -p, --proxy <url>             proxy url
   -h, --help                    output usage information
 
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Options:
   -c, --concurrency <n>         number of requests to make at the same time - default=50
   -r, --registry <registry>     specify a registry
   -p, --proxy <url>             proxy url
+  --insecure                    ignore TLS (SSL) certificate errors
   -h, --help                    output usage information
 
 ```

--- a/src/Downloader.js
+++ b/src/Downloader.js
@@ -39,6 +39,7 @@ export default class Downloader extends Step {
     const tarballUri = tarball ? tarball.replace(/https:\/\/registry.npmjs.org/i, 'http://registry.npmjs.org') : tarball;
     const outDir = this.args.archive ? OUT_DIR : OUT_DIR.substring(1);
     const folder = this.args.flat ? outDir : `${outDir}/${pkg}/-`;
+    const proxy = this.args.proxy || null;
     const stripped = pkg.includes('/') && (this.args.flat ? pkg.replace('/', '-') : pkg.split('/')[1]);
     const strippedName = stripped || pkg;
     const hash = crypto.createHash('sha1');
@@ -58,7 +59,7 @@ export default class Downloader extends Step {
               resolve();
             }
           });
-        request(tarballUri)
+        request.get(tarballUri, { proxy })
           .on('error', () => reject())
           .on('response', (res) => {
             const size = parseInt(res.headers['content-length'], 10);

--- a/src/Downloader.js
+++ b/src/Downloader.js
@@ -36,7 +36,6 @@ export default class Downloader extends Step {
   }
 
   getPackage(pkg, version, { shasum, tarball }) {
-    const tarballUri = tarball ? tarball.replace(/https:\/\/registry.npmjs.org/i, 'http://registry.npmjs.org') : tarball;
     const outDir = this.args.archive ? OUT_DIR : OUT_DIR.substring(1);
     const folder = this.args.flat ? outDir : `${outDir}/${pkg}/-`;
     const proxy = this.args.proxy || null;
@@ -59,7 +58,7 @@ export default class Downloader extends Step {
               resolve();
             }
           });
-        request.get(tarballUri, { proxy })
+        request.get(tarball, { proxy })
           .on('error', () => reject())
           .on('response', (res) => {
             const size = parseInt(res.headers['content-length'], 10);

--- a/src/Downloader.js
+++ b/src/Downloader.js
@@ -36,6 +36,7 @@ export default class Downloader extends Step {
   }
 
   getPackage(pkg, version, { shasum, tarball }) {
+    const tarballUri = tarball ? tarball.replace(/https:\/\/registry.npmjs.org/i, 'http://registry.npmjs.org') : tarball;
     const outDir = this.args.archive ? OUT_DIR : OUT_DIR.substring(1);
     const folder = this.args.flat ? outDir : `${outDir}/${pkg}/-`;
     const stripped = pkg.includes('/') && (this.args.flat ? pkg.replace('/', '-') : pkg.split('/')[1]);
@@ -57,7 +58,7 @@ export default class Downloader extends Step {
               resolve();
             }
           });
-        request(tarball)
+        request(tarballUri)
           .on('error', () => reject())
           .on('response', (res) => {
             const size = parseInt(res.headers['content-length'], 10);

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -117,10 +117,11 @@ export default class Resolver extends Step {
 
   resolveDependencies(pkg, range, { requested } = {}) {
     const regUrl = this.args.registry || REGISTRY_URL;
+    const proxy = this.args.proxy || null;
     if (this.alreadyHaveValidVersion(pkg, range)) {
       return false;
     }
-    return rp(`${regUrl}/${pkg.replace('/', '%2f')}`, { json: true })
+    return rp(`${regUrl}/${pkg.replace('/', '%2f')}`, { json: true, proxy })
       .then((res) => {
         if (!res.versions) {
           throw new PBError(`Unable to find "${pkg}" version - ignoring.`, 'error');

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ args
   .option('-c, --concurrency <n>', 'number of requests to make at the same time - default=50', parseInt)
   .option('-r, --registry <registry>', 'specify a registry')
   .option('-p, --proxy <url>', 'proxy url')
+  .option('--insecure', 'ignore TLS (SSL) certificate errors')
   .parse(process.argv);
 
 const resolver = new Resolver(args);
@@ -42,6 +43,9 @@ function init() {
   return Promise.try(() => {
     if (fs.existsSync(OUT_DIR)) {
       throw new PBError(`Output dir "${OUT_DIR}" already exists.`, 'error');
+    } else if (args.insecure) {
+      // Workaround for self-signed certificates.
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     }
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ args
   .option('-A, --all-versions-recursive', 'download all versions of specified packages and dependencies')
   .option('-c, --concurrency <n>', 'number of requests to make at the same time - default=50', parseInt)
   .option('-r, --registry <registry>', 'specify a registry')
+  .option('-p, --proxy <url>', 'proxy url')
   .parse(process.argv);
 
 const resolver = new Resolver(args);


### PR DESCRIPTION
This PR does two things:
1. Uses `http://registry.npmjs.org` instead of `https://registry.npmjs.org` for tarball downloads.
  This was already preferred when fetching package metadata [as seen here](https://github.com/alexbrazier/package-bundle/blob/486158ad2301ca3352b1c1d957452e5c2d2bb3e5/src/Resolver.js#L10). So I believe this is consistent with existing behavior.
1. Adds basic proxy support.
  While it would be possible to rely on [environment variables](https://www.npmjs.com/package/request#controlling-proxy-behaviour-using-environment-variables) I felt it would be helpful to explicitly support setting a proxy for downloads.

These were the features I needed to get this tool working behind a highly controlled corporate gateway.



